### PR TITLE
DRAFT: ansible will use latest version

### DIFF
--- a/.github/workflows/ansible-lint sap_general_preconfigure.yml
+++ b/.github/workflows/ansible-lint sap_general_preconfigure.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths: 
       - 'roles/sap_general_preconfigure/**'
+  workflow_dispatch:
 jobs:
   ansible-lint:
 

--- a/.github/workflows/ansible-lint sap_general_preconfigure.yml
+++ b/.github/workflows/ansible-lint sap_general_preconfigure.yml
@@ -14,14 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
+    - name: Install dependencies
+      run: pip install ansible-lint
+    
     - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@master
-      with:
-        targets: |
-          ./roles/sap_general_preconfigure
-        override-deps: |
-          ansible-core==2.12.1
-          ansible-lint==5.3.2
+      run: ansible-lint ./roles/sap_general_preconfigure/*
 
 # Static: use Ansible Community Edition 4.8.0, with lowest compatible Ansible Core 2.11.6 and use Ansible-lint 5.2.1


### PR DESCRIPTION
This PR is to enable ansible-lint to use latest ansible version for CI workflows for each roles. 

Currently testing for 
roles/sap_general_preconfigure